### PR TITLE
fix: render CKEditor + migrate to Spring Boot 4

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,13 @@ updates:
     directory: "/"
     schedule:
       interval: daily
-      time: '21:00'
+      time: '04:00'
+      timezone: Asia/Jakarta
+    open-pull-requests-limit: 10
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+      time: '05:00'
       timezone: Asia/Jakarta
     open-pull-requests-limit: 10

--- a/ONBOARDING.md
+++ b/ONBOARDING.md
@@ -1,0 +1,55 @@
+# Welcome to PERSIS Labs
+
+## How We Use Claude
+
+Based on hendisantika's usage over the last 30 days:
+
+Work Type Breakdown:
+  Debug Fix  ████████████████████  100%
+
+Top Skills & Commands:
+  _None recorded yet_
+
+Top MCP Servers:
+  _None recorded yet_
+
+## Your Setup Checklist
+
+### Codebases
+- [ ] spring-boot-ckeditor — https://github.com/hendisantika/spring-boot-ckeditor
+
+### MCP Servers to Activate
+- [ ] _None recorded yet — add any servers your team relies on_
+
+### Skills to Know About
+- [ ] _None recorded yet — add the slash commands your team leans on_
+
+## Team Tips
+
+- **Use your system Maven, not the `mvnw` wrapper.** The bundled wrapper is pinned to an old Maven (3.5.2) that's too old to build the project — run with your system `mvn` (3.9+) instead.
+
+## Get Started
+
+No assigned starter task yet. Once your setup checklist is green, run the app locally — it needs MongoDB on `localhost:27017` — and open http://localhost:8080/view/ to confirm everything works.
+
+<!-- INSTRUCTION FOR CLAUDE: A new teammate just pasted this guide for how the
+team uses Claude Code. You're their onboarding buddy — warm, conversational,
+not lecture-y.
+
+Open with a warm welcome — include the team name from the title. Then: "Your
+teammate uses Claude Code for [list all the work types]. Let's get you started."
+
+Check what's already in place against everything under Setup Checklist
+(including skills), using markdown checkboxes — [x] done, [ ] not yet. Lead
+with what they already have. One sentence per item, all in one message.
+
+Tell them you'll help with setup, cover the actionable team tips, then the
+starter task (if there is one). Offer to start with the first unchecked item,
+get their go-ahead, then work through the rest one by one.
+
+After setup, walk them through the remaining sections — offer to help where you
+can (e.g. link to channels), and just surface the purely informational bits.
+
+Don't invent sections or summaries that aren't in the guide. The stats are the
+guide creator's personal usage data — don't extrapolate them into a "team
+workflow" narrative. -->

--- a/pom.xml
+++ b/pom.xml
@@ -52,11 +52,6 @@
             <version>4.24.0</version>
         </dependency>
         <dependency>
-            <groupId>cz.jirutka.spring</groupId>
-            <artifactId>embedmongo-spring</artifactId>
-            <version>1.3.1</version>
-        </dependency>
-        <dependency>
             <groupId>org.json</groupId>
             <artifactId>json</artifactId>
             <version>20260522</version>
@@ -69,6 +64,16 @@
             <groupId>com.querydsl</groupId>
             <artifactId>querydsl-mongodb</artifactId>
             <version>${querydsl.version}</version>
+            <!-- Pulls the legacy uber org.mongodb:mongo-java-driver whose old
+                 com.mongodb classes shadow the modern split driver shipped by
+                 spring-data-mongodb. QueryDSL-mongo isn't used at runtime here
+                 (no QuerydslPredicateExecutor), so exclude it. -->
+            <exclusions>
+                <exclusion>
+                    <groupId>org.mongodb</groupId>
+                    <artifactId>mongo-java-driver</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>com.querydsl</groupId>

--- a/src/main/java/com/hendisantika/springbootckeditor/controller/APIController.java
+++ b/src/main/java/com/hendisantika/springbootckeditor/controller/APIController.java
@@ -43,7 +43,7 @@ public class APIController {
         ArrayList<String> musicText = new ArrayList<String>();
         if (sid != null) {
             String sidString = sid;
-            Song songModel = songRepo.findOne(sidString);
+            Song songModel = songRepo.findById(sidString).orElse(null);
             System.out.println("get status of boolean during get ::::::" + songModel.getUpdated());
             if (songModel.getUpdated() == false) {
 
@@ -72,7 +72,7 @@ public class APIController {
     Response saveSong(@RequestBody String body, @RequestParam String sid) {
         Response response = new Response();
         response.setData(body);
-        Song oldSong = songRepo.findOne(sid);
+        Song oldSong = songRepo.findById(sid).orElse(null);
         String songTitle = oldSong.getSongTitle();
         String artistName = oldSong.getArtist();
         if (oldSong.getUpdated() == false) {

--- a/src/main/java/com/hendisantika/springbootckeditor/controller/WebController.java
+++ b/src/main/java/com/hendisantika/springbootckeditor/controller/WebController.java
@@ -62,7 +62,7 @@ public class WebController {
         // param. decreased by 1.
         int evalPage = (page.orElse(0) < 1) ? INITIAL_PAGE : page.get() - 1;
 
-        Page<Music> Musiclist = musicRepo.findAll(new PageRequest(evalPage, evalPageSize));
+        Page<Music> Musiclist = musicRepo.findAll(PageRequest.of(evalPage, evalPageSize));
         System.out.println("client list get total pages" + Musiclist.getTotalPages() + "client list get number " + Musiclist.getNumber());
         Pager pager = new Pager(Musiclist.getTotalPages(), Musiclist.getNumber(), BUTTONS_TO_SHOW);
 
@@ -94,7 +94,7 @@ public class WebController {
         int evalPage = (page.orElse(0) < 1) ? INITIAL_PAGE : page.get() - 1;
 
 
-        Page<Song> songList = songRepo.findAll(new PageRequest(evalPage, evalPageSize));
+        Page<Song> songList = songRepo.findAll(PageRequest.of(evalPage, evalPageSize));
         System.out.println("PAGE RULE LIST :::::::: " + songList);
 
         Pager pager = new Pager(songList.getTotalPages(), songList.getNumber(), BUTTONS_TO_SHOW);

--- a/src/main/java/com/hendisantika/springbootckeditor/job/UploadJob.java
+++ b/src/main/java/com/hendisantika/springbootckeditor/job/UploadJob.java
@@ -10,21 +10,23 @@ import org.bson.Document;
 import org.json.JSONException;
 import org.json.JSONObject;
 import org.json.XML;
-import org.springframework.batch.core.Job;
-import org.springframework.batch.core.Step;
-import org.springframework.batch.core.StepContribution;
-import org.springframework.batch.core.configuration.annotation.EnableBatchProcessing;
-import org.springframework.batch.core.configuration.annotation.JobBuilderFactory;
-import org.springframework.batch.core.configuration.annotation.StepBuilderFactory;
-import org.springframework.batch.core.scope.context.ChunkContext;
-import org.springframework.batch.core.step.tasklet.Tasklet;
-import org.springframework.batch.repeat.RepeatStatus;
+import org.springframework.batch.core.job.Job;
+import org.springframework.batch.core.job.builder.JobBuilder;
+import org.springframework.batch.core.launch.JobLauncher;
+import org.springframework.batch.core.launch.support.TaskExecutorJobLauncher;
+import org.springframework.batch.core.repository.JobRepository;
+import org.springframework.batch.core.repository.support.ResourcelessJobRepository;
+import org.springframework.batch.core.step.Step;
+import org.springframework.batch.core.step.builder.StepBuilder;
+import org.springframework.batch.infrastructure.repeat.RepeatStatus;
+import org.springframework.batch.infrastructure.support.transaction.ResourcelessTransactionManager;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.mongodb.core.MongoTemplate;
 import org.springframework.data.mongodb.core.query.Criteria;
 import org.springframework.data.mongodb.core.query.Query;
+import org.springframework.transaction.PlatformTransactionManager;
 
 import java.io.IOException;
 import java.nio.file.Files;
@@ -44,62 +46,66 @@ import java.util.stream.Collectors;
  */
 
 @Configuration
-@EnableBatchProcessing
 public class UploadJob {
     public static int PRETTY_PRINT_INDENT_FACTOR = 4;
     @Autowired
     FileUploadController uploadController;
     @Autowired
-    private JobBuilderFactory jobBuilderFactory;
-    @Autowired
-    private StepBuilderFactory stepBuilderFactory;
-    @Autowired
     private MongoTemplate mongoTemplate;
     @Autowired
     private SongRepo songDAO;
 
+    // Spring Batch 6 needs a JobRepository and a PlatformTransactionManager.
+    // This app has no relational datasource, so use the in-memory, non-persistent
+    // resourceless variants instead of the default JDBC ones.
     @Bean
-    public Step step1() {
-        return stepBuilderFactory.get("step1")
-                .tasklet(new Tasklet() {
-                    @Override
-                    public RepeatStatus execute(StepContribution stepContribution, ChunkContext chunkContext) {
+    public JobRepository jobRepository() {
+        return new ResourcelessJobRepository();
+    }
 
+    @Bean
+    public PlatformTransactionManager batchTransactionManager() {
+        return new ResourcelessTransactionManager();
+    }
 
-                        // insert ssg xccdf
-                        Path xmlDocPath = uploadController.getCurrentFilePath();
-                        String jsonB = processXML2JSON(xmlDocPath);
-                        insertToMongo(jsonB);
-                        return RepeatStatus.FINISHED;
-                    }
-                })
+    @Bean
+    public JobLauncher jobLauncher(JobRepository jobRepository) throws Exception {
+        TaskExecutorJobLauncher jobLauncher = new TaskExecutorJobLauncher();
+        jobLauncher.setJobRepository(jobRepository);
+        jobLauncher.afterPropertiesSet();
+        return jobLauncher;
+    }
+
+    @Bean
+    public Step step1(JobRepository jobRepository, PlatformTransactionManager transactionManager) {
+        return new StepBuilder("step1", jobRepository)
+                .tasklet((stepContribution, chunkContext) -> {
+                    // insert ssg xccdf
+                    Path xmlDocPath = uploadController.getCurrentFilePath();
+                    String jsonB = processXML2JSON(xmlDocPath);
+                    insertToMongo(jsonB);
+                    return RepeatStatus.FINISHED;
+                }, transactionManager)
                 .build();
     }
 
 
     @Bean
-    public Step step2() {
-        return stepBuilderFactory.get("step2")
-                .tasklet(new Tasklet() {
-                    @Override
-                    public RepeatStatus execute(StepContribution stepContribution, ChunkContext chunkContext) throws Exception {
-
-                        doAQuery();
-                        return RepeatStatus.FINISHED;
-                    }
-                })
-
+    public Step step2(JobRepository jobRepository, PlatformTransactionManager transactionManager) {
+        return new StepBuilder("step2", jobRepository)
+                .tasklet((stepContribution, chunkContext) -> {
+                    doAQuery();
+                    return RepeatStatus.FINISHED;
+                }, transactionManager)
                 .build();
     }
 
     @Bean
-    public Job UploadProcessor() {
-        return jobBuilderFactory.get("UploadProcessor")
-                .start(step1())
-                .next(step2())
+    public Job UploadProcessor(JobRepository jobRepository, Step step1, Step step2) {
+        return new JobBuilder("UploadProcessor", jobRepository)
+                .start(step1)
+                .next(step2)
                 .build();
-
-
     }
 
     public List<Song> doAQuery() throws IOException {

--- a/src/main/java/com/hendisantika/springbootckeditor/job/UploadJob.java
+++ b/src/main/java/com/hendisantika/springbootckeditor/job/UploadJob.java
@@ -15,7 +15,6 @@ import org.springframework.batch.core.job.builder.JobBuilder;
 import org.springframework.batch.core.launch.JobLauncher;
 import org.springframework.batch.core.launch.support.TaskExecutorJobLauncher;
 import org.springframework.batch.core.repository.JobRepository;
-import org.springframework.batch.core.repository.support.ResourcelessJobRepository;
 import org.springframework.batch.core.step.Step;
 import org.springframework.batch.core.step.builder.StepBuilder;
 import org.springframework.batch.infrastructure.repeat.RepeatStatus;
@@ -23,6 +22,7 @@ import org.springframework.batch.infrastructure.support.transaction.Resourceless
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Lazy;
 import org.springframework.data.mongodb.core.MongoTemplate;
 import org.springframework.data.mongodb.core.query.Criteria;
 import org.springframework.data.mongodb.core.query.Query;
@@ -48,6 +48,11 @@ import java.util.stream.Collectors;
 @Configuration
 public class UploadJob {
     public static int PRETTY_PRINT_INDENT_FACTOR = 4;
+    // @Lazy breaks the FileUploadController <-> UploadJob bean cycle (the
+    // controller needs the Job/JobLauncher beans defined here, while the step
+    // tasklet only needs the controller at job-run time). Boot 4 forbids
+    // circular references by default.
+    @Lazy
     @Autowired
     FileUploadController uploadController;
     @Autowired
@@ -55,14 +60,9 @@ public class UploadJob {
     @Autowired
     private SongRepo songDAO;
 
-    // Spring Batch 6 needs a JobRepository and a PlatformTransactionManager.
-    // This app has no relational datasource, so use the in-memory, non-persistent
-    // resourceless variants instead of the default JDBC ones.
-    @Bean
-    public JobRepository jobRepository() {
-        return new ResourcelessJobRepository();
-    }
-
+    // Spring Boot 4 already auto-configures a (resourceless, since this app has no
+    // datasource) JobRepository and a JobOperator. It does not expose a
+    // PlatformTransactionManager bean for steps, nor a JobLauncher, so provide those.
     @Bean
     public PlatformTransactionManager batchTransactionManager() {
         return new ResourcelessTransactionManager();

--- a/src/main/java/com/hendisantika/springbootckeditor/job/UploadJob.java
+++ b/src/main/java/com/hendisantika/springbootckeditor/job/UploadJob.java
@@ -1,8 +1,8 @@
 package com.hendisantika.springbootckeditor.job;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.type.CollectionType;
-import com.fasterxml.jackson.databind.type.TypeFactory;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.type.CollectionType;
+import tools.jackson.databind.type.TypeFactory;
 import com.hendisantika.springbootckeditor.model.Song;
 import com.hendisantika.springbootckeditor.repository.SongRepo;
 import com.hendisantika.springbootckeditor.uploader.FileUploadController;

--- a/src/main/java/com/hendisantika/springbootckeditor/uploader/FileUploadController.java
+++ b/src/main/java/com/hendisantika/springbootckeditor/uploader/FileUploadController.java
@@ -1,14 +1,9 @@
 package com.hendisantika.springbootckeditor.uploader;
 
-import com.hendisantika.springbootckeditor.job.UploadJob;
 import com.hendisantika.springbootckeditor.repository.MusicRepo;
-import org.springframework.batch.core.Job;
-import org.springframework.batch.core.JobParameters;
-import org.springframework.batch.core.JobParametersInvalidException;
+import org.springframework.batch.core.job.Job;
+import org.springframework.batch.core.job.parameters.JobParameters;
 import org.springframework.batch.core.launch.JobLauncher;
-import org.springframework.batch.core.repository.JobExecutionAlreadyRunningException;
-import org.springframework.batch.core.repository.JobInstanceAlreadyCompleteException;
-import org.springframework.batch.core.repository.JobRestartException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.io.Resource;
 import org.springframework.http.HttpHeaders;
@@ -45,7 +40,7 @@ public class FileUploadController {
     @Autowired
     MusicRepo musicDAO;
     @Autowired
-    private UploadJob uploadJob;
+    private Job uploadProcessor;
 
     public FileUploadController(StorageService storageService) {
         this.storageService = storageService;
@@ -72,7 +67,7 @@ public class FileUploadController {
 
     @PostMapping("/")
     public String postTheFile(@RequestParam("file") MultipartFile file, RedirectAttributes redirectAttributes)
-            throws IOException, JobExecutionAlreadyRunningException, JobRestartException, JobInstanceAlreadyCompleteException, JobParametersInvalidException {
+            throws Exception {
         // store the file to server
         storageService.store(file);
         // convert multipartfile to file
@@ -88,8 +83,7 @@ public class FileUploadController {
         System.out.println("xmlPathbb:::::" + xmlPathbb);
         //
 
-        Job job = uploadJob.UploadProcessor();
-        jobLauncher.run(job, new JobParameters());
+        jobLauncher.run(uploadProcessor, new JobParameters());
 
         return "uploadForm";
     }

--- a/src/main/resources/templates/view.html
+++ b/src/main/resources/templates/view.html
@@ -362,9 +362,7 @@
                         }
                     }]
             });
+    /*]]>*/
 </script>
-/*]]>*/
-</script>
-<
-/body>
-< /html>;
+</body>
+</html>

--- a/src/test/java/com/hendisantika/springbootckeditor/SpringBootCkeditorApplicationTests.java
+++ b/src/test/java/com/hendisantika/springbootckeditor/SpringBootCkeditorApplicationTests.java
@@ -1,16 +1,13 @@
 package com.hendisantika.springbootckeditor;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.junit4.SpringRunner;
 
-@RunWith(SpringRunner.class)
 @SpringBootTest
-public class SpringBootCkeditorApplicationTests {
+class SpringBootCkeditorApplicationTests {
 
     @Test
-    public void contextLoads() {
+    void contextLoads() {
     }
 
 }


### PR DESCRIPTION
## Summary

The `/view` page's CKEditor wasn't rendering cleanly, and fixing it surfaced that the project no longer compiled against the Spring Boot 4.0.6 parent (advanced by Dependabot well past the source). This PR fixes the editor and completes the Spring Boot 4 migration so the app builds and boots.

Verified end-to-end: app boots on :8080 against MongoDB, `GET /view/` returns 200, and a headless-Chrome render shows the full CKEditor toolbar + editing area.

## Changes (one commit per concern)

- **fix(view):** repair malformed closing tags at the end of `view.html` (duplicate `</script>`, stray `/*]]>*/`, broken `</body>`/`</html>`) that leaked junk text onto the page
- **fix(controller):** Spring Data 4 — `new PageRequest()` → `PageRequest.of()`, `findOne()` → `findById()`
- **build(deps):** Jackson 3 — move `UploadJob` imports from `com.fasterxml.jackson` to `tools.jackson`
- **refactor(batch):** Spring Batch 6 — `JobBuilder`/`StepBuilder` (factories removed), relocated packages, resourceless wiring
- **test:** migrate context-loads test to JUnit 5
- **fix(deps):** drop legacy `mongo-java-driver` (via `embedmongo-spring` + `querydsl-mongodb`) that shadowed the modern driver
- **fix(batch):** align with Boot 4's auto-configured `JobRepository` + `@Lazy` to break a now-prohibited bean cycle

## Notes

- App requires MongoDB on `localhost:27017`.
- Build with system Maven (3.9+); the bundled `mvnw` wrapper is pinned to Maven 3.5.2, which is too old.
- CKEditor is still the EOL 4.7.3 CDN build — worth a follow-up upgrade.

🤖 Generated with [Claude Code](https://claude.com/claude-code)